### PR TITLE
Part 1 - Analysis changes

### DIFF
--- a/analyses/domain_analysis.sql
+++ b/analyses/domain_analysis.sql
@@ -8,35 +8,52 @@ Questions to Answer:
 
 */
 
-select
-  -- entity_with_domains.entity_type
-  -- , trim(both '"' from domain_flat.domain_urn) as domain_urn
-  json_extract_string(domain_details.entity_details, '$.name') as domain_name
-  , json_extract_string(domain_details.entity_details, '$.description') as domain_description
-  , count(distinct entity_with_domains.urn) as entity_count
-from
-  stg_datahub_entities as entity_with_domains,
-  unnest(json_extract_string(entity_with_domains.domains, '$.domains')::string[]) as domain_flat(domain_urn)
-left join
-  stg_datahub_entities as domain_details
-  on trim(both '"' from domain_flat.domain_urn) = domain_details.urn
-where
-  entity_with_domains.domains is not null
-group by 1, 2
-order by 2 desc
-limit 1
-;
+with entity_with_domains as ( --separated into CTEs for readability
+	select
+	  trim(both '"' from domain_flat.domain_urn) as domain_urn
+	  , entity_with_domains.urn as entity_urn
+	  , entity_type
+	from
+	  stg_datahub_entities as entity_with_domains
+	  , unnest(json_extract_string(entity_with_domains.domains, '$.domains')::string[]) as domain_flat(domain_urn)
+	  
+	  where entity_with_domains.entity_type in ('dataset', 'dashboard') --filters high in run order and filters latent case where domains are assigned to other entity types
+)
 
+, entity_w_domain_det as (
+	select
+	  entity_with_domains.domain_urn
+	  , json_extract_string(domain_details.entity_details, '$.name') as domain_name
+	  , json_extract_string(domain_details.entity_details, '$.description') as domain_description
+	  , count(distinct entity_with_domains.entity_urn) as dashboard_dataset_count
+	from entity_with_domains
+	left join
+	  stg_datahub_entities as domain_details
+	  on domain_urn = domain_details.urn  
+
+	group by all -- group by all is simpler than 1, 2, 3 etc.
+)
+
+select
+  domain_name
+  , domain_description
+  , dashboard_dataset_count --made name explicit
+
+from entity_w_domain_det
+
+qualify rank() over (order by dashboard_dataset_count desc) = 1 --using qualify rank so ties show up instead of creating a nondeteministic query
+
+-- order by was ordering by description, not count
 
 /*
 
 Query Output:
 
-┌─────────────┬────────────────────────────────────────────────────────────────────────────────────────────────┬──────────────┐
-│ domain_name │                                       domain_description                                       │ entity_count │
-│   varchar   │                                            varchar                                             │    int64     │
-├─────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────┤
-│ E-Commerce  │ The E-Commerce Data Domain within Datahub provides access to datasets related to online reta…  │           65 │
-└─────────────┴────────────────────────────────────────────────────────────────────────────────────────────────┴──────────────┘
+┌─────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─────────────────────────┐
+│ domain_name │                                       domain_description                                                           │ dashboard_dataset_count │
+│   varchar   │                                            varchar                                                                 │    int64                │
+├─────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────┤
+│    Finance  | All data entities required for the Finance team to generate and maintain revenue forecasts and relevant reporting. |    285                  │ 
+└─────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────────────┘
 
 */

--- a/analyses/domain_analysis.sql
+++ b/analyses/domain_analysis.sql
@@ -25,7 +25,7 @@ with entity_with_domains as ( --separated into CTEs for readability
 	  entity_with_domains.domain_urn
 	  , json_extract_string(domain_details.entity_details, '$.name') as domain_name
 	  , json_extract_string(domain_details.entity_details, '$.description') as domain_description
-	  , count(distinct entity_with_domains.entity_urn) as dashboard_dataset_count
+	  , count(entity_with_domains.entity_urn) as dashboard_dataset_count --no change with distinct count, but could be a performance hit at scale
 	from entity_with_domains
 	left join
 	  stg_datahub_entities as domain_details

--- a/analyses/glossary_term_analysis.sql
+++ b/analyses/glossary_term_analysis.sql
@@ -8,42 +8,46 @@ Questions to Answer:
 */ 
 
 with urns_with_terms as (
-select
-    urn,
-    glossary_terms,
-    json_extract_string(term.value, '$.urn') as term_urn
-from
-    stg_datahub_entities
-cross join unnest(json_extract(glossary_terms, '$.terms')::json[]) as term(value)
-where
-    glossary_terms is not null
+    select
+      json_extract_string(term.value, '$.urn') as term_urn
+      , count(*) as dashboard_dataset_count --aggregation higher in run order for performance
+    from
+      stg_datahub_entities
+      , unnest(json_extract(glossary_terms, '$.terms')::json[]) as term(value)
+    where
+      glossary_terms is not null
+      and entity_type in ('dashboard', 'dataset') --filters latent case where domains are assigned to other entity types
+        
+    group by all
 )
 
 select
-  -- stg_datahub_entities.urn as term_urn,
-  json_extract_string(stg_datahub_entities.entity_details, '$.name') as term_name
-  , count(distinct urns_with_terms.urn) as urn_count
+  urns_with_terms.term_urn 
+  , json_extract_string(stg_datahub_entities.entity_details, '$.name') as term_name
+  , urns_with_terms.dashboard_dataset_count
+
 from
   urns_with_terms
 left join
   stg_datahub_entities
   on stg_datahub_entities.urn = urns_with_terms.term_urn
-group by 1--, 2
-order by 2 desc
+
+order by urns_with_terms.dashboard_dataset_count desc
 ;
 
 /*
 
 Query Output:
 
-┌───────────────────────┬───────────┐
-│       term_name       │ urn_count │
-│        varchar        │   int64   │
-├───────────────────────┼───────────┤
-│ Gold Tier             │       668 │
-│ Confidential          │        60 │
-│ Return Rate           │        16 │
-│ Certification Pending │         1 │
-└───────────────────────┴───────────┘
+┌──────────────────────────────────────────────────────────┬───────────────────────┬─────────────────────────┐
+│                        term_urn                          │       term_name       │ dashboard_dataset_count │
+│                         varchar                          │        varchar        │         int64           │
+├──────────────────────────────────────────────────────────┼───────────────────────┤─────────────────────────┤
+│ urn:li:glossaryTerm:9afa9a59-93b2-47cb-9094-aa342eec24ad │ Gold Tier             │                     668 │
+│ urn:li:glossaryTerm:Classification.Confidential          │ Confidential          │                      60 │
+│ urn:li:glossaryTerm:Ecommerce.ReturnRate                 │ Return Rate           │                       9 │
+│ urn:li:glossaryTerm:Adoption.ReturnRate                  │ Return Rate           │                       7 │
+│ urn:li:glossaryTerm:c10049f8-64dc-49d5-bc25-fd1d953fac05 │ Certification Pending │                       1 │
+└──────────────────────────────────────────────────────────┴───────────────────────┴─────────────────────────┘
 
 */

--- a/analyses/ownership_analysis.sql
+++ b/analyses/ownership_analysis.sql
@@ -8,39 +8,56 @@ Questions to Answer:
 
 */
 
+with users as ( --doing this in CTE for readability
+	select
+	  urn
+	  , json_extract_string(entity_details, '$.fullName') full_name -- (minor & audience specific) "who" implies their name
+	  , json_extract_string(entity_details, '$.username') user_name
+      , json_extract_string(entity_details, '$.title') as title 
+      
+	from 
+	  stg_datahub_entities
+	where 
+	  entity_type in ('user')
+)
+
 select 
-    a.entity_type,
-    -- c.owner_urn,
-    json_extract_string(b.entity_details, '$.username') username,
-    json_extract_string(b.entity_details, '$.title') as title ,
-    count(distinct a.urn) as cnt
-from stg_datahub_entities a,
-     unnest(json_extract(owners, '$.owners')::json[]) c(owner_urn)
-LEFT OUTER JOIN 
-stg_datahub_entities b
-on json_extract_string(c.owner_urn, '$.owner')=b.urn
-group by 1,2,3--,4
-order by 2,1
-;
+  a.entity_type --this adds a row for mitch - OK to leave in depending on audience
+  , users.full_name
+  , users.user_name
+  , users.title
+  , count(*) dataset_dashboard_count
+--  , count(distinct a.urn) as cnt
+from stg_datahub_entities as a  
+  , unnest(json_extract(owners, '$.owners')::json[]) as term(owner_urn)
+left outer join
+  users
+  on json_extract_string(owner_urn, '$.owner') = users.urn
+
+where entity_type in ('dashboard', 'dataset') --explicit about entity types
+
+group by all
+
+order by full_name, entity_type desc
 
 
 /*
 
 Query Output:
 
-┌─────────────┬───────────────────────┬─────────────────────────┬───────┐
-│ entity_type │       username        │          title          │  cnt  │
-│   varchar   │        varchar        │         varchar         │ int64 │
-├─────────────┼───────────────────────┼─────────────────────────┼───────┤
-│ dataset     │ chris@longtail.com    │ Data Engineer           │   218 │
-│ dataset     │ eddie@longtail.com    │ Analyst                 │   360 │
-│ dataset     │ melina@longtail.com   │ Analyst                 │    24 │
-│ dashboard   │ mitch@longtail.com    │ Software Engineer       │    21 │
-│ dataset     │ mitch@longtail.com    │ Software Engineer       │    97 │
-│ dataset     │ phillipe@longtail.com │ Fulfillment Coordinator │    96 │
-│ dataset     │ roselia@longtail.com  │ Analyst                 │    73 │
-│ dataset     │ shannon@longtail.com  │ Analytics Engineer      │   300 │
-│ dataset     │ terrance@longtail.com │ Fulfillment Coordinator │    32 │
-└─────────────┴───────────────────────┴─────────────────────────┴───────┘
+┌─────────────┬───────────────────────┬───────────────────────┬─────────────────────────┬───────┐
+│ entity_type │       username        |      username         │          title          │  cnt  │
+│   varchar   │        varchar        |       varchar         │         varchar         │ int64 │
+├─────────────┼───────────────────────┼───────────────────────┼─────────────────────────┼───────┤
+│ dataset     │ Chris Ewing           | chris@longtail.com    │ Data Engineer           │   218 │
+│ dataset     │ Eddie Winton          | eddie@longtail.com    │ Analyst                 │   360 │
+│ dataset     │ Melina Eliez          | melina@longtail.com   │ Analyst                 │    24 │
+│ dashboard   │ Mitch Terzi           | mitch@longtail.com    │ Software Engineer       │    21 │
+│ dataset     │ Mitch Terzi           | mitch@longtail.com    │ Software Engineer       │    97 │
+│ dataset     │ Phillipe Fissenden    | phillipe@longtail.com │ Fulfillment Coordinator │    96 │
+│ dataset     │ Roselia Himsworth     | roselia@longtail.com  │ Analyst                 │    73 │
+│ dataset     │ Shannon Lovett        | shannon@longtail.com  │ Analytics Engineer      │   300 │
+│ dataset     │ Terrance Gude         | terrance@longtail.com │ Fulfillment Coordinator │    32 │
+└─────────────┴───────────────────────┴───────────────────────┴─────────────────────────┴───────┘
 
 */


### PR DESCRIPTION
**Summary**
Change analysis files for improved readability & accuracy.

**Changes**

domain_analysis.sql
- order by/limit resulted in incorrect answer, swapped for rank window function to handle possible ties
- removed domain_description is null filter
- Changed entity_count column to be more explicit
- Filtered dataset to the explicit entities asked about - no change in asnwer to removes possilbe latent error
- moved entity_with_domains into a CTE for readability
- changed group by 1, 2, 3 -> group by all

glossary_term_analysis.sql
- commas left aligned for consistency with domain_analysis
- move aggregation higher in CTE for performance & filtered to relevant entity type
- OPEN QUESTION: Return Rate (name) shows under two urns, split in new query, but merged into one row is fine depending on audience - included urn to show why Return Rate is split into two rows
- group by all/order by explicit for readability

ownership_analysis.sql
- commas left aligned for consistency with domain_analysis
- explciit entity type filters to prevent latent errors
- users as CTE for readability
- Included names since "who" generally means name - but is audience specific
- OPEN QUESTION: Mitch is split into two rows because he owns two types of entities - OK depending on the audience
- group by all/order by explicit for readability
- removed distinct count for performance at scale